### PR TITLE
Don't enforce mounting / as ro, when we remounted it rw before.

### DIFF
--- a/initramfs/scripts/touch
+++ b/initramfs/scripts/touch
@@ -383,7 +383,6 @@ mountroot()
 		FSTAB=${rootmnt}/etc/fstab
 		touch ${rootmnt}/run/image.fstab
 		mount -o bind ${rootmnt}/run/image.fstab $FSTAB || panic "drop to adb"
-		echo "/dev/root / rootfs defaults,ro 0 0" >> $FSTAB
 
 		# Process the list of bind-mounts
 		# (but don't mount them, mountall will do it)


### PR DESCRIPTION
As far as I understand, this line is not needed since we do all of the mounting ourselves. It actually serves the purpose of forcing the rootfs to be mounted read-only even though we explicitly mounted it read-write previously.