### PR TITLE
A rather large refactor

### DIFF
--- a/initramfs/scripts/functions
+++ b/initramfs/scripts/functions
@@ -73,6 +73,8 @@ panic()
 		chvt 1
 	fi
 
+	export REASON="$@"
+
 	echo "$@"
 	# Disallow console access
 	if [ -n "${panic}" ]; then

--- a/initramfs/scripts/panic/adbd
+++ b/initramfs/scripts/panic/adbd
@@ -58,7 +58,7 @@ inject_loop() {
 }
 
 
-usb_setup "UBports initrd Debug setting up"
+usb_setup "ubports-boot telnet 192.168.2.15: ${REASON}"
 
 USB_IFACE=notfound
 /sbin/ifconfig rndis0 $LOCAL_IP && USB_IFACE=rndis0

--- a/initramfs/scripts/panic/adbd
+++ b/initramfs/scripts/panic/adbd
@@ -59,6 +59,7 @@ inject_loop() {
 
 
 usb_setup "ubports-boot telnet 192.168.2.15: ${REASON}"
+echo "initrd: PANIC for reason: ${REASON}" >/dev/kmsg || true
 
 USB_IFACE=notfound
 /sbin/ifconfig rndis0 $LOCAL_IP && USB_IFACE=rndis0

--- a/initramfs/scripts/touch
+++ b/initramfs/scripts/touch
@@ -426,7 +426,7 @@ mountroot() {
 	# Mount the android system partition to a temporary location
 	mkdir -p /android-system
 	MOUNT="ro"
-	[ -e ${rootmnt}/userdata/.writable_device_image -a -e ${rootmnt}/userdata/.writable_image ] && MOUNT="rw"
+	[ -e ${rootmnt}/userdata/.writable_device_image -a -e ${rootmnt}/userdata/.writable_device_image ] && MOUNT="rw"
 	tell_kmsg "mounting android system image $MOUNT"
 	if [ $file_layout = "halium" ]; then
 		# rootfs.img and Android system.img are separate

--- a/initramfs/scripts/touch
+++ b/initramfs/scripts/touch
@@ -493,7 +493,7 @@ mountroot() {
 
 		# Get device information
 		device=$(grep ^ro.product.device= /android-system/build.prop |sed -e 's/.*=//')
-		[ -z "$device" ] && device="unknown"; tell_kmsg "WARNING: Didn't find a device name. Is the Android system image mounted correctly?"
+		[ -z "$device" ] && device="unknown" && tell_kmsg "WARNING: Didn't find a device name. Is the Android system image mounted correctly?"
 		tell_kmsg "device is $device"
 
 		# Mount some tmpfs

--- a/initramfs/scripts/touch
+++ b/initramfs/scripts/touch
@@ -279,7 +279,7 @@ mountroot()
 	identify_boot_mode
 
 	# Real partition or image, we both need charger mode.....
-	if ( [ -e /tmpmnt/system.img ] || [ -n "$syspart" ] ) && [ "$BOOT_MODE" = "android" ]; then
+	if ( [ -e /tmpmnt/rootfs.img ] || [ -n "$syspart" ] ) && [ "$BOOT_MODE" = "android" ]; then
 		# Factory/charger mode, just boot directly into the android rootfs
 		mkdir -p /ubuntu-system
 		mkdir -p /android-rootfs
@@ -289,12 +289,12 @@ mountroot()
 		if [ -n "$syspart" ]; then
 			mount -o rw $syspart /ubuntu-system
 		else
-			mount -o loop,rw /tmpmnt/system.img /ubuntu-system
+			mount -o loop,rw /tmpmnt/rootfs.img /ubuntu-system
 		fi
 		mount -o remount,ro /ubuntu-system
 
 		echo "initrd: mounting android system image" >/dev/kmsg || true
-		mount -o loop,ro /ubuntu-system/var/lib/lxc/android/system.img /android-system
+		mount -o loop,ro /tmpmnt/system.img /android-system
 
 		echo "initrd: extracting android ramdisk" >/dev/kmsg || true
 		OLD_CWD=$(pwd)
@@ -328,7 +328,7 @@ mountroot()
 		ln -s ../init ${rootmnt}/sbin/init
 		ln -s ../init ${rootmnt}/sbin/recovery
 		echo "initrd: booting android..." >/dev/kmsg || true
-    elif [ -e /tmpmnt/system.img -o -n "$syspart" ]; then
+    elif [ -e /tmpmnt/rootfs.img -o -n "$syspart" ]; then
 	    # Loop-mounted flipped model
 		# Transition .developer_mode to .writable_image
 		[ -e /tmpmnt/.developer_mode ] && mv /tmpmnt/.developer_mode /tmpmnt/.writable_image
@@ -342,13 +342,13 @@ mountroot()
 		if [ -n "$syspart" ]; then
 			mount -o rw $syspart ${rootmnt}
 		else
-			mount -o loop,rw /tmpmnt/system.img ${rootmnt}
+			mount -o loop,rw /tmpmnt/rootfs.img ${rootmnt}
 		fi
 		if [ -e /tmpmnt/.writable_image ]; then
-			echo "initrd: mounting system.img (image developer mode)" >/dev/kmsg || true
+			echo "initrd: mounting rootfs.img (image developer mode)" >/dev/kmsg || true
 			mountroot_status="$?"
 		else
-			echo "initrd: mounting system.img (user mode)" >/dev/kmsg || true
+			echo "initrd: mounting rootfs.img (user mode)" >/dev/kmsg || true
 			mount -o remount,ro ${rootmnt}
 			mountroot_status="$?"
 		fi
@@ -364,7 +364,7 @@ mountroot()
 		MOUNT="ro"
 		[ -e ${rootmnt}/userdata/.writable_device_image -a -e ${rootmnt}/userdata/.writable_image ] && MOUNT="rw"
 		echo "initrd: mounting device image as $MOUNT" >/dev/kmsg || true
-		mount -o loop,$MOUNT ${rootmnt}/var/lib/lxc/android/system.img /android-system
+		mount -o loop,$MOUNT ${rootmnt}/userdata/system.img /android-system
 
 		# Get device information
 		device=$(grep ^ro.product.device= /android-system/build.prop |sed -e 's/.*=//')
@@ -462,7 +462,7 @@ mountroot()
 		mount_android_partitions "${rootmnt}/var/lib/lxc/android/rootfs/fstab*" ${rootmnt}/android
 
 		# system is a special case
-		echo "initrd: mounting ${rootmnt}/var/lib/lxc/android/system.img as ${rootmnt}/android/system" >/dev/kmsg || true
+		echo "initrd: mounting ${rootmnt}/userdata/system.img as ${rootmnt}/android/system" >/dev/kmsg || true
 		mount --move /android-system ${rootmnt}/android/system
 
 		# Ubuntu overlay available in the Android system image (hardware specific configs)

--- a/initramfs/scripts/touch
+++ b/initramfs/scripts/touch
@@ -1,7 +1,6 @@
 # Local filesystem mounting			-*- shell-script -*-
 
-pre_mountroot()
-{
+pre_mountroot() {
 	[ "$quiet" != "y" ] && log_begin_msg "Running /scripts/local-top"
 	run_scripts /scripts/local-top
 	[ "$quiet" != "y" ] && log_end_msg
@@ -12,8 +11,7 @@ tell_kmsg() {
 	echo $1 >/dev/kmsg || true
 }
 
-identify_boot_mode()
-{
+identify_boot_mode() {
 	# Our current list of supported boot modes:
 	## BOOT_MODE = ubuntu and android
 	BOOT_MODE='ubuntu'
@@ -212,7 +210,6 @@ resize_userdata_if_needed() {
 identify_file_layout() {
 	# Determine if we have a Halium rootfs.img & system.img or legacy ubuntu.img
 
-	#
 	# $file_layout = "ubports" means there is an ubuntu.img which contains an
 	# android system.img at /var/lib/lxc/android/system.img
 	#
@@ -317,8 +314,20 @@ process_bind_mounts() {
 	done
 }
 
-mountroot()
-{
+extract_android_ramdisk() {
+	# Extracts the ramdisk from /android-system/boot/android-ramdisk.img to
+	# /android-rootfs
+
+	# NOTE: we should find a faster way of doing that or cache it
+	tell_kmsg "initrd: extracting android ramdisk"
+	OLD_CWD=$(pwd)
+	mount -n -t tmpfs tmpfs /android-rootfs
+	cd /android-rootfs
+	cat /android-system/boot/android-ramdisk.img | gzip -d | cpio -i
+	cd $OLD_CWD
+}
+
+mountroot() {
 	# list of possible userdata partition names
 	partlist="userdata UDA DATAFS USERDATA"
 
@@ -415,31 +424,34 @@ mountroot()
 		mount -o loop,rw $imagefile /ubuntu-system
 	fi
 
-	tell_kmsg "initrd: extracting android ramdisk"
-	OLD_CWD=$(pwd)
-	mount -n -t tmpfs tmpfs /android-rootfs
-	cd /android-rootfs
-	cat /android-system/boot/android-ramdisk.img | gzip -d | cpio -i
-	cd $OLD_CWD
+	# Mount the android system partition to a temporary location
+	mkdir -p /android-system
+	MOUNT="ro"
+	[ -e ${rootmnt}/userdata/.writable_device_image -a -e ${rootmnt}/userdata/.writable_image ] && MOUNT="rw"
+	tell_kmsg "initrd: mounting android system image $MOUNT"
+	if [ $file_layout = "halium" ]; then
+		# rootfs.img and Android system.img are separate
+		tell_kmsg "initrd: mounting android system image from userdata partition"
+		mount -o loop,$MOUNT /tmpmnt/system.img /android-system
+	else
+		# Android system.img is inside Ubuntu image
+		tell_kmsg "initrd: mounting android system image from system rootfs"
+		mount -o loop,$MOUNT /ubuntu-system/var/lib/lxc/android/system.img /android-system
+	fi
+
+	extract_android_ramdisk
 
 	# Determine whether we should boot in rootfs or Android mode
 	if ( [ -e $imagefile ] || [ -n "$syspart" ] ) && [ "$BOOT_MODE" = "android" ]; then
 		# Bootloader says this is factory or charger mode, boot into Android.
-		tell_kmsg "initrd: using android ramdisk as rootfs"
+		tell_kmsg "initrd: Android boot mode for factory or charger mode"
 
 		mount /ubuntu-system -o remount,ro
 		mount --move /android-rootfs ${rootmnt}
+		mount --move /android-system ${rootmnt}/system
 
-		# Mounting system
-		if [ $file_layout = "halium" ]; then
-			# rootfs.img and Android system.img are separate
-			tell_kmsg "initrd: mounting android system image from userdata partition"
-			mount -o loop,ro /tmpmnt/system.img /android-system
-		else
-			# Android system.img is inside Ubuntu image
-			tell_kmsg "initrd: mounting android system image from system rootfs"
-			mount -o loop,ro /ubuntu-system/var/lib/lxc/android/system.img /android-system
-		fi
+		# Mount all the Android partitions
+		mount_android_partitions "${rootmnt}/fstab*" ${rootmnt}
 
 		mkdir -p ${rootmnt}/ubuntu-system
 		mount --move /ubuntu-system ${rootmnt}/ubuntu-system
@@ -454,19 +466,19 @@ mountroot()
 		# Set ubuntu version properties
 		set_ubuntu_version_properties ${rootmnt}/ubuntu-system ${rootmnt}/data
 
-		# Mount all the remaining android partitions
-		mount_android_partitions "${rootmnt}/fstab*" ${rootmnt}
-
 		# Make sure we're booting into android's init
 		ln -s ../init ${rootmnt}/sbin/init
 		ln -s ../init ${rootmnt}/sbin/recovery
 		tell_kmsg "initrd: booting android..."
     elif [ -e $imagefile -o -n "$syspart" ]; then
 	    # Regular image boot
+		tell_kmsg "initrd: Normal boot"
 
 		mount --move /ubuntu-system ${rootmnt}
 
-		if [ -e /tmpmnt/.writable_image ]; then
+		# If either (android) /data/.writable_image or (on rootfs) 
+		# /.writable_image exist, mount the rootfs as rw
+		if [ -e /tmpmnt/.writable_image ] || [ -e ${rootmnt}/.writable_image ]; then
 			tell_kmsg "initrd: mounting $imagefile (image developer mode)"
 			mountroot_status="$?"
 		else
@@ -479,14 +491,6 @@ mountroot()
 		# Set ubuntu version properties
 		mkdir -p ${rootmnt}/userdata/android-data
 		set_ubuntu_version_properties ${rootmnt} ${rootmnt}/userdata/android-data
-
-		# Mount the android system partition to a temporary location
-		mkdir -p /android-system
-
-		MOUNT="ro"
-		[ -e ${rootmnt}/userdata/.writable_device_image -a -e ${rootmnt}/userdata/.writable_image ] && MOUNT="rw"
-		tell_kmsg "initrd: mounting android system image $MOUNT"
-		mount /android-system -o remount,$MOUNT
 
 		# Get device information
 		device=$(grep ^ro.product.device= /android-system/build.prop |sed -e 's/.*=//')
@@ -503,13 +507,7 @@ mountroot()
 
 		process_bind_mounts
 
-		# Extract the fstab from the android initrd
-		# NOTE: we should find a faster way of doing that or cache it
-		OLD_CWD=$(pwd)
-		mount -n -t tmpfs tmpfs ${rootmnt}/var/lib/lxc/android/rootfs
-		cd ${rootmnt}/var/lib/lxc/android/rootfs
-		cat /android-system/boot/android-ramdisk.img | gzip -d | cpio -i
-		cd $OLD_CWD
+		mount --move /android-rootfs ${rootmnt}/var/lib/lxc/android/rootfs
 
 		# Mount all the Android partitions
 		mount_android_partitions "${rootmnt}/var/lib/lxc/android/rootfs/fstab*" ${rootmnt}/android

--- a/initramfs/scripts/touch
+++ b/initramfs/scripts/touch
@@ -7,6 +7,11 @@ pre_mountroot()
 	[ "$quiet" != "y" ] && log_end_msg
 }
 
+tell_kmsg() {
+	# Echos a string into /dev/kmsg, ignoring errors.
+	echo $1 >/dev/kmsg || true
+}
+
 identify_boot_mode()
 {
 	# Our current list of supported boot modes:
@@ -42,7 +47,7 @@ identify_boot_mode()
 		esac
 	fi
 
-	echo "initrd: boot mode: $BOOT_MODE" >/dev/kmsg || true
+	tell_kmsg "initrd: boot mode: $BOOT_MODE"
 }
 
 set_ubuntu_version_properties() {
@@ -97,7 +102,7 @@ mount_android_partitions() {
 	fstab=$1
 	mount_root=$2
 
-	echo "initrd: checking fstab $fstab for additional mount points" >/dev/kmsg || true
+	tell_kmsg "initrd: checking fstab $fstab for additional mount points"
 
 	cat ${fstab} | while read line; do
 		set -- $line
@@ -113,7 +118,7 @@ mount_android_partitions() {
 		label=$(echo $1 | awk -F/ '{print $NF}')
 		[ -z "$label" ] && continue
 
-		echo "initrd: checking mount label $label" >/dev/kmsg || true
+		tell_kmsg "initrd: checking mount label $label"
 
 		# In case fstab provides /dev/mmcblk0p* lines
 		path="/dev/$label"
@@ -127,7 +132,7 @@ mount_android_partitions() {
 		[ ! -e "$path" ] && continue
 
 		mkdir -p ${mount_root}/$2
-		echo "initrd: mounting $path as ${mount_root}/$2" >/dev/kmsg || true
+		tell_kmsg "initrd: mounting $path as ${mount_root}/$2"
 		mount $path ${mount_root}/$2 -t $3 -o $4
 	done
 }
@@ -200,8 +205,116 @@ resize_userdata_if_needed() {
 	dblocks=$(($pblocks-4*$fsblocks))
 	if [ $dblocks -gt 10000 ];then
 		resize2fs -f $path
-		echo "initrd: resized userdata filesystem to fill $path" >/dev/kmsg || true
+		tell_kmsg "initrd: resized userdata filesystem to fill $path"
 	fi
+}
+
+identify_file_layout() {
+	# Determine if we have a Halium rootfs.img & system.img or legacy ubuntu.img
+
+	#
+	# $file_layout = "ubports" means there is an ubuntu.img which contains an
+	# android system.img at /var/lib/lxc/android/system.img
+	#
+	# = "halium" means there is a separate rootfs.img and system.img on userdata
+	#
+	# = "partition" means the rootfs is located on the device's system partition
+	# and will contain /var/lib/lxc/android/system.img
+
+
+	if [ -e /tmpmnt/ubuntu.img ]; then
+		imagefile=/tmpmnt/ubuntu.img
+		file_layout="ubports"
+	elif [ -e /tmpmnt/rootfs.img ]; then
+		imagefile=/tmpmnt/rootfs.img
+		file_layout="halium"
+	else
+		file_layout="parition"
+	fi
+
+}
+
+process_bind_mounts() {
+	# Goes over /etc/system-image/writable-paths to create the correct fstab for
+	# the bind-mounts. Writes them into ${rootmnt}/run/image.fstab which is
+	# bind-mounted to /etc/fstab
+
+	if [ ! -e ${rootmnt}/etc/system-image/writable-paths ]; then
+		tell_kmsg "initrd: This rootfs does not have any writable-paths defined"
+		return 0
+	fi
+
+	# Prepare the fstab
+	FSTAB=${rootmnt}/etc/fstab
+	touch ${rootmnt}/run/image.fstab
+	mount -o bind ${rootmnt}/run/image.fstab $FSTAB || panic "drop to adb"
+	echo "/dev/root / rootfs defaults,ro 0 0" >> $FSTAB
+
+	tell_kmsg "initrd: Adding bind-mounts to $FSTAB"
+	# Process the list of bind-mounts
+	# (but don't mount them, mountall will do it)
+	cat ${rootmnt}/etc/system-image/writable-paths | while read line; do
+		set -- $line
+		# Skip invalid/commented entries
+		([ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ] || [ -z "$5" ]) && continue
+		[ "$1" = "#" ] && continue
+
+		# Skip invalid mount points
+		dstpath="${rootmnt}/$1"
+		[ ! -e "$dstpath" ] && continue
+
+		if [ "$3" = "temporary" ]; then
+			# Temporary entries are simple, just mount a tmpfs
+			echo "tmpfs $1 tmpfs $5 0 0" >> $FSTAB
+		elif [ "$3" = "persistent" ] || [ "$3" = "synced" ]; then
+			# Figure out the source path
+			if [ "$2" = "auto" ]; then
+				srcpath="${rootmnt}/userdata/system-data/$1"
+				path="/userdata/system-data/$1"
+			else
+				srcpath="${rootmnt}/userdata/$2"
+				path="/userdata/$2"
+			fi
+
+			if [ ! -e "$srcpath" ]; then
+				# Process new persistent or synced paths
+				dstown=$(stat -c "%u:%g" $dstpath)
+				dstmode=$(stat -c "%a" $dstpath)
+				mkdir -p ${srcpath%/*}
+				if [ ! -d "$dstpath" ]; then
+					# Deal with redirected files
+					if [ "$4" = "transition" ]; then
+						cp -a $dstpath $srcpath
+					else
+						touch $srcpath
+						chown $dstown $srcpath
+						chmod $dstmode $srcpath
+					fi
+				else
+					# Deal with redirected directories
+					if [ "$4" = "transition" ] || [ "$3" = "synced" ]; then
+						cp -aR $dstpath $srcpath
+					else
+						mkdir $srcpath
+						chown $dstown $srcpath
+						chmod $dstmode $srcpath
+					fi
+				fi
+			elif [ "$3" = "synced" ]; then
+				# Process existing synced paths
+				sync_dirs $dstpath . $srcpath
+			fi
+
+			# Write the fstab entry
+			if [ "$5" = "none" ]; then
+				echo "$path $1 none bind 0 0" >> $FSTAB
+			else
+				echo "$path $1 none bind,$5 0 0" >> $FSTAB
+			fi
+		else
+			continue
+		fi
+	done
 }
 
 mountroot()
@@ -243,11 +356,11 @@ mountroot()
 	fi
 
 	if [ -z "$path" ]; then
-		echo "initrd: Couldn't find data partition. Spawning adbd ..." >/dev/kmsg || true
+		tell_kmsg "initrd: Couldn't find data partition. Spawning adbd ..."
 		panic "Couldn't find data partition. Spawning adbd ..."
 	fi
 
-	echo "initrd: checking filesystem integrity for the userdata partition" >/dev/kmsg || true
+	tell_kmsg "initrd: checking filesystem integrity for the userdata partition"
 	# Mounting and umounting first, let the kernel handle the journal and
 	# orphaned inodes (faster than e2fsck). Then, just run e2fsck forcing -y.
 	# Also check the amount of time used by to check the filesystem.
@@ -256,16 +369,17 @@ mountroot()
 	umount /tmpmnt
 	e2fsck -y $path > /run/initramfs/e2fsck.out 2>&1
 	fsck_end=`date +%s`
-	echo "initrd: checking filesystem for userdata took (including e2fsck) $((fsck_end-fsck_start)) seconds" >/dev/kmsg || true
+	tell_kmsg "initrd: checking filesystem for userdata took (including e2fsck) $((fsck_end-fsck_start)) seconds"
 
 	resize_userdata_if_needed ${path}
 
-	echo "initrd: mounting $path" >/dev/kmsg || true
+	tell_kmsg "initrd: mounting $path"
 
 	# Mount the data partition to a temporary mount point
 	# FIXME: data=journal used as a workaround for bug 1387214
 	mount -o discard,data=journal $path /tmpmnt
 
+	# Set $syspart if it is specified as systempart= on the command line
 	if grep -q systempart= /proc/cmdline; then
 		for x in $(cat /proc/cmdline); do
 			case ${x} in
@@ -277,37 +391,56 @@ mountroot()
 	fi
 
 	identify_boot_mode
+	identify_file_layout
 
-	# Real partition or image, we both need charger mode.....
-	if ( [ -e /tmpmnt/rootfs.img ] || [ -n "$syspart" ] ) && [ "$BOOT_MODE" = "android" ]; then
-		# Factory/charger mode, just boot directly into the android rootfs
-		mkdir -p /ubuntu-system
-		mkdir -p /android-rootfs
-		mkdir -p /android-system
+	# If both $imagefile and $syspart are set, something is wrong . The strange
+	# output from this could be a clue in that situation.
+	tell_kmsg "initrd: Ubuntu rootfs is $imagefile $syspart"
 
-		echo "initrd: mounting ubuntu system partition" >/dev/kmsg || true
-		if [ -n "$syspart" ]; then
-			mount -o rw $syspart /ubuntu-system
-		else
-			mount -o loop,rw /tmpmnt/rootfs.img /ubuntu-system
-		fi
-		mount -o remount,ro /ubuntu-system
+	# Prepare the root filesystem
+	# NOTE: We mount it read-write in all cases, then remount read-only.
+	#       This is to workaround a behaviour change in busybox which now
+	#       uses read-only loops if the fs is initially mounted read-only.
+	#       An alternative implementation would be to add losetup support
+	#       to busybox and do the mount in two steps (rw loop, ro fs).
 
-		echo "initrd: mounting android system image" >/dev/kmsg || true
-		mount -o loop,ro /tmpmnt/system.img /android-system
+	mkdir -p /ubuntu-system
+	mkdir -p /android-rootfs
+	mkdir -p /android-system
 
-		echo "initrd: extracting android ramdisk" >/dev/kmsg || true
-		OLD_CWD=$(pwd)
-		mount -n -t tmpfs tmpfs /android-rootfs
-		cd /android-rootfs
-		cat /android-system/boot/android-ramdisk.img | gzip -d | cpio -i
-		cd $OLD_CWD
+	tell_kmsg "initrd: mounting system rootfs at /ubuntu-system"
+	if [ -n "$syspart" ]; then
+		mount -o rw $syspart /ubuntu-system
+	else
+		mount -o loop,rw $imagefile /ubuntu-system
+	fi
 
-		echo "initrd: using android ramdisk as rootfs" >/dev/kmsg || true
+	tell_kmsg "initrd: extracting android ramdisk"
+	OLD_CWD=$(pwd)
+	mount -n -t tmpfs tmpfs /android-rootfs
+	cd /android-rootfs
+	cat /android-system/boot/android-ramdisk.img | gzip -d | cpio -i
+	cd $OLD_CWD
+
+	# Determine whether we should boot in rootfs or Android mode
+	if ( [ -e $imagefile ] || [ -n "$syspart" ] ) && [ "$BOOT_MODE" = "android" ]; then
+		# Bootloader says this is factory or charger mode, boot into Android.
+		tell_kmsg "initrd: using android ramdisk as rootfs"
+
+		mount /ubuntu-system -o remount,ro
 		mount --move /android-rootfs ${rootmnt}
 
 		# Mounting system
-		mount --move /android-system ${rootmnt}/system
+		if [ $file_layout = "halium" ]; then
+			# rootfs.img and Android system.img are separate
+			tell_kmsg "initrd: mounting android system image from userdata partition"
+			mount -o loop,ro /tmpmnt/system.img /android-system
+		else
+			# Android system.img is inside Ubuntu image
+			tell_kmsg "initrd: mounting android system image from system rootfs"
+			mount -o loop,ro /ubuntu-system/var/lib/lxc/android/system.img /android-system
+		fi
+
 		mkdir -p ${rootmnt}/ubuntu-system
 		mount --move /ubuntu-system ${rootmnt}/ubuntu-system
 
@@ -327,28 +460,17 @@ mountroot()
 		# Make sure we're booting into android's init
 		ln -s ../init ${rootmnt}/sbin/init
 		ln -s ../init ${rootmnt}/sbin/recovery
-		echo "initrd: booting android..." >/dev/kmsg || true
-    elif [ -e /tmpmnt/rootfs.img -o -n "$syspart" ]; then
-	    # Loop-mounted flipped model
-		# Transition .developer_mode to .writable_image
-		[ -e /tmpmnt/.developer_mode ] && mv /tmpmnt/.developer_mode /tmpmnt/.writable_image
+		tell_kmsg "initrd: booting android..."
+    elif [ -e $imagefile -o -n "$syspart" ]; then
+	    # Regular image boot
 
-		# Prepare the root filesystem
-		# NOTE: We mount it read-write in all cases, then remount read-only.
-		#       This is to workaround a behaviour change in busybox which now
-		#       uses read-only loops if the fs is initially mounted read-only.
-		#       An alternative implementation would be to add losetup support
-		#       to busybox and do the mount in two steps (rw loop, ro fs).
-		if [ -n "$syspart" ]; then
-			mount -o rw $syspart ${rootmnt}
-		else
-			mount -o loop,rw /tmpmnt/rootfs.img ${rootmnt}
-		fi
+		mount --move /ubuntu-system ${rootmnt}
+
 		if [ -e /tmpmnt/.writable_image ]; then
-			echo "initrd: mounting rootfs.img (image developer mode)" >/dev/kmsg || true
+			tell_kmsg "initrd: mounting $imagefile (image developer mode)"
 			mountroot_status="$?"
 		else
-			echo "initrd: mounting rootfs.img (user mode)" >/dev/kmsg || true
+			tell_kmsg "initrd: mounting $imagefile (user mode)"
 			mount -o remount,ro ${rootmnt}
 			mountroot_status="$?"
 		fi
@@ -363,13 +485,13 @@ mountroot()
 
 		MOUNT="ro"
 		[ -e ${rootmnt}/userdata/.writable_device_image -a -e ${rootmnt}/userdata/.writable_image ] && MOUNT="rw"
-		echo "initrd: mounting device image as $MOUNT" >/dev/kmsg || true
-		mount -o loop,$MOUNT ${rootmnt}/userdata/system.img /android-system
+		tell_kmsg "initrd: mounting android system image $MOUNT"
+		mount /android-system -o remount,$MOUNT
 
 		# Get device information
 		device=$(grep ^ro.product.device= /android-system/build.prop |sed -e 's/.*=//')
 		[ -z "$device" ] && device="unknown"
-		echo "initrd: device is $device" >/dev/kmsg || true
+		tell_kmsg "initrd: device is $device"
 
 		# Mount some tmpfs
 		mkdir -p ${rootmnt}/android
@@ -379,76 +501,7 @@ mountroot()
 		# Create some needed paths on tmpfs
 		mkdir -p ${rootmnt}/android/data ${rootmnt}/android/system
 
-		# Prepare the fstab
-		FSTAB=${rootmnt}/etc/fstab
-		touch ${rootmnt}/run/image.fstab
-		mount -o bind ${rootmnt}/run/image.fstab $FSTAB || panic "drop to adb"
-		echo "/dev/root / rootfs defaults,ro 0 0" >> $FSTAB
-
-		# Process the list of bind-mounts
-		# (but don't mount them, mountall will do it)
-		cat ${rootmnt}/etc/system-image/writable-paths | while read line; do
-			set -- $line
-			# Skip invalid/commented entries
-			([ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ] || [ -z "$5" ]) && continue
-			[ "$1" = "#" ] && continue
-
-			# Skip invalid mount points
-			dstpath="${rootmnt}/$1"
-			[ ! -e "$dstpath" ] && continue
-
-			if [ "$3" = "temporary" ]; then
-				# Temporary entries are simple, just mount a tmpfs
-				echo "tmpfs $1 tmpfs $5 0 0" >> $FSTAB
-			elif [ "$3" = "persistent" ] || [ "$3" = "synced" ]; then
-				# Figure out the source path
-				if [ "$2" = "auto" ]; then
-					srcpath="${rootmnt}/userdata/system-data/$1"
-					path="/userdata/system-data/$1"
-				else
-					srcpath="${rootmnt}/userdata/$2"
-					path="/userdata/$2"
-				fi
-
-				if [ ! -e "$srcpath" ]; then
-					# Process new persistent or synced paths
-					dstown=$(stat -c "%u:%g" $dstpath)
-					dstmode=$(stat -c "%a" $dstpath)
-					mkdir -p ${srcpath%/*}
-					if [ ! -d "$dstpath" ]; then
-						# Deal with redirected files
-						if [ "$4" = "transition" ]; then
-							cp -a $dstpath $srcpath
-						else
-							touch $srcpath
-							chown $dstown $srcpath
-							chmod $dstmode $srcpath
-						fi
-					else
-						# Deal with redirected directories
-						if [ "$4" = "transition" ] || [ "$3" = "synced" ]; then
-							cp -aR $dstpath $srcpath
-						else
-							mkdir $srcpath
-							chown $dstown $srcpath
-							chmod $dstmode $srcpath
-						fi
-					fi
-				elif [ "$3" = "synced" ]; then
-					# Process existing synced paths
-					sync_dirs $dstpath . $srcpath
-				fi
-
-				# Write the fstab entry
-				if [ "$5" = "none" ]; then
-					echo "$path $1 none bind 0 0" >> $FSTAB
-				else
-					echo "$path $1 none bind,$5 0 0" >> $FSTAB
-				fi
-			else
-				continue
-			fi
-		done
+		process_bind_mounts
 
 		# Extract the fstab from the android initrd
 		# NOTE: we should find a faster way of doing that or cache it
@@ -462,7 +515,7 @@ mountroot()
 		mount_android_partitions "${rootmnt}/var/lib/lxc/android/rootfs/fstab*" ${rootmnt}/android
 
 		# system is a special case
-		echo "initrd: mounting ${rootmnt}/userdata/system.img as ${rootmnt}/android/system" >/dev/kmsg || true
+		tell_kmsg "initrd: moving Android system to /android/system"
 		mount --move /android-system ${rootmnt}/android/system
 
 		# Ubuntu overlay available in the Android system image (hardware specific configs)
@@ -490,7 +543,7 @@ mountroot()
 		for user in ${rootmnt}/userdata/user-data/*
 		do
 			if [ -d ${rootmnt}/custom/home ] && [ ! -e "$user/.customized" ]; then
-				echo "initrd: copying custom content tp " >/dev/kmsg || true
+				tell_kmsg "initrd: copying custom content tp "
 				cp -Rap ${rootmnt}/custom/home/* "$user/"
 				cp -Rap ${rootmnt}/custom/home/.[a-zA-Z0-9]* "$user/"
 				touch "$user/.customized"
@@ -499,15 +552,9 @@ mountroot()
 			fi
 		done
 
-
-	# Old flipped model
-	elif [ -d /tmpmnt/ubuntu ]; then
-		mount --bind /tmpmnt/ubuntu ${rootmnt}
-		mountroot_status="$?"
-
-	# Possibly a re-partitioned device
 	else
-		echo "initrd: Couldn't find a system partition." >/dev/kmsg || true
+		# Possibly a re-partitioned device
+		tell_kmsg "initrd: Couldn't find a system partition."
 		panic "Couldn't find a system partition. Spawning adbd ..."
 	fi
 

--- a/initramfs/scripts/touch
+++ b/initramfs/scripts/touch
@@ -419,8 +419,19 @@ mountroot() {
 	tell_kmsg "mounting system rootfs at /ubuntu-system"
 	if [ -n "$syspart" ]; then
 		mount -o rw $syspart /ubuntu-system
+		mount -o remount,ro /ubuntu-system
 	else
 		mount -o loop,rw $imagefile /ubuntu-system
+		# If either (android) /data/.writable_image or (on rootfs) 
+		# /.writable_image exist, mount the rootfs as rw
+		if [ -e /tmpmnt/.writable_image ] || [ -e $/ubuntu-system/.writable_image ]; then
+			tell_kmsg "mounting $imagefile (image developer mode)"
+			mountroot_status="$?"
+		else
+			tell_kmsg "mounting $imagefile (user mode)"
+			mount -o remount,ro /ubuntu-system
+			mountroot_status="$?"
+		fi
 	fi
 
 	# Mount the android system partition to a temporary location
@@ -475,16 +486,6 @@ mountroot() {
 
 		mount --move /ubuntu-system ${rootmnt}
 
-		# If either (android) /data/.writable_image or (on rootfs) 
-		# /.writable_image exist, mount the rootfs as rw
-		if [ -e /tmpmnt/.writable_image ] || [ -e ${rootmnt}/.writable_image ]; then
-			tell_kmsg "mounting $imagefile (image developer mode)"
-			mountroot_status="$?"
-		else
-			tell_kmsg "mounting $imagefile (user mode)"
-			mount -o remount,ro ${rootmnt}
-			mountroot_status="$?"
-		fi
 		mount --move /tmpmnt ${rootmnt}/userdata
 
 		# Set ubuntu version properties

--- a/initramfs/scripts/touch
+++ b/initramfs/scripts/touch
@@ -8,7 +8,7 @@ pre_mountroot() {
 
 tell_kmsg() {
 	# Echos a string into /dev/kmsg, ignoring errors.
-	echo $1 >/dev/kmsg || true
+	echo "initrd: $1" >/dev/kmsg || true
 }
 
 identify_boot_mode() {
@@ -45,7 +45,7 @@ identify_boot_mode() {
 		esac
 	fi
 
-	tell_kmsg "initrd: boot mode: $BOOT_MODE"
+	tell_kmsg "boot mode: $BOOT_MODE"
 }
 
 set_ubuntu_version_properties() {
@@ -100,7 +100,7 @@ mount_android_partitions() {
 	fstab=$1
 	mount_root=$2
 
-	tell_kmsg "initrd: checking fstab $fstab for additional mount points"
+	tell_kmsg "checking fstab $fstab for additional mount points"
 
 	cat ${fstab} | while read line; do
 		set -- $line
@@ -116,7 +116,7 @@ mount_android_partitions() {
 		label=$(echo $1 | awk -F/ '{print $NF}')
 		[ -z "$label" ] && continue
 
-		tell_kmsg "initrd: checking mount label $label"
+		tell_kmsg "checking mount label $label"
 
 		# In case fstab provides /dev/mmcblk0p* lines
 		path="/dev/$label"
@@ -130,7 +130,7 @@ mount_android_partitions() {
 		[ ! -e "$path" ] && continue
 
 		mkdir -p ${mount_root}/$2
-		tell_kmsg "initrd: mounting $path as ${mount_root}/$2"
+		tell_kmsg "mounting $path as ${mount_root}/$2"
 		mount $path ${mount_root}/$2 -t $3 -o $4
 	done
 }
@@ -203,7 +203,7 @@ resize_userdata_if_needed() {
 	dblocks=$(($pblocks-4*$fsblocks))
 	if [ $dblocks -gt 10000 ];then
 		resize2fs -f $path
-		tell_kmsg "initrd: resized userdata filesystem to fill $path"
+		tell_kmsg "resized userdata filesystem to fill $path"
 	fi
 }
 
@@ -237,7 +237,7 @@ process_bind_mounts() {
 	# bind-mounted to /etc/fstab
 
 	if [ ! -e ${rootmnt}/etc/system-image/writable-paths ]; then
-		tell_kmsg "initrd: This rootfs does not have any writable-paths defined"
+		tell_kmsg "This rootfs does not have any writable-paths defined"
 		return 0
 	fi
 
@@ -247,7 +247,7 @@ process_bind_mounts() {
 	mount -o bind ${rootmnt}/run/image.fstab $FSTAB || panic "drop to adb"
 	echo "/dev/root / rootfs defaults,ro 0 0" >> $FSTAB
 
-	tell_kmsg "initrd: Adding bind-mounts to $FSTAB"
+	tell_kmsg "Adding bind-mounts to $FSTAB"
 	# Process the list of bind-mounts
 	# (but don't mount them, mountall will do it)
 	cat ${rootmnt}/etc/system-image/writable-paths | while read line; do
@@ -319,7 +319,7 @@ extract_android_ramdisk() {
 	# /android-rootfs
 
 	# NOTE: we should find a faster way of doing that or cache it
-	tell_kmsg "initrd: extracting android ramdisk"
+	tell_kmsg "extracting android ramdisk"
 	OLD_CWD=$(pwd)
 	mount -n -t tmpfs tmpfs /android-rootfs
 	cd /android-rootfs
@@ -365,11 +365,11 @@ mountroot() {
 	fi
 
 	if [ -z "$path" ]; then
-		tell_kmsg "initrd: Couldn't find data partition. Spawning adbd ..."
+		tell_kmsg "Couldn't find data partition. Spawning adbd ..."
 		panic "Couldn't find data partition. Spawning adbd ..."
 	fi
 
-	tell_kmsg "initrd: checking filesystem integrity for the userdata partition"
+	tell_kmsg "checking filesystem integrity for the userdata partition"
 	# Mounting and umounting first, let the kernel handle the journal and
 	# orphaned inodes (faster than e2fsck). Then, just run e2fsck forcing -y.
 	# Also check the amount of time used by to check the filesystem.
@@ -378,11 +378,11 @@ mountroot() {
 	umount /tmpmnt
 	e2fsck -y $path > /run/initramfs/e2fsck.out 2>&1
 	fsck_end=`date +%s`
-	tell_kmsg "initrd: checking filesystem for userdata took (including e2fsck) $((fsck_end-fsck_start)) seconds"
+	tell_kmsg "checking filesystem for userdata took (including e2fsck) $((fsck_end-fsck_start)) seconds"
 
 	resize_userdata_if_needed ${path}
 
-	tell_kmsg "initrd: mounting $path"
+	tell_kmsg "mounting $path"
 
 	# Mount the data partition to a temporary mount point
 	# FIXME: data=journal used as a workaround for bug 1387214
@@ -404,7 +404,7 @@ mountroot() {
 
 	# If both $imagefile and $syspart are set, something is wrong . The strange
 	# output from this could be a clue in that situation.
-	tell_kmsg "initrd: Ubuntu rootfs is $imagefile $syspart"
+	tell_kmsg "Ubuntu rootfs is $imagefile $syspart"
 
 	# Prepare the root filesystem
 	# NOTE: We mount it read-write in all cases, then remount read-only.
@@ -417,7 +417,7 @@ mountroot() {
 	mkdir -p /android-rootfs
 	mkdir -p /android-system
 
-	tell_kmsg "initrd: mounting system rootfs at /ubuntu-system"
+	tell_kmsg "mounting system rootfs at /ubuntu-system"
 	if [ -n "$syspart" ]; then
 		mount -o rw $syspart /ubuntu-system
 	else
@@ -428,14 +428,14 @@ mountroot() {
 	mkdir -p /android-system
 	MOUNT="ro"
 	[ -e ${rootmnt}/userdata/.writable_device_image -a -e ${rootmnt}/userdata/.writable_image ] && MOUNT="rw"
-	tell_kmsg "initrd: mounting android system image $MOUNT"
+	tell_kmsg "mounting android system image $MOUNT"
 	if [ $file_layout = "halium" ]; then
 		# rootfs.img and Android system.img are separate
-		tell_kmsg "initrd: mounting android system image from userdata partition"
+		tell_kmsg "mounting android system image from userdata partition"
 		mount -o loop,$MOUNT /tmpmnt/system.img /android-system
 	else
 		# Android system.img is inside Ubuntu image
-		tell_kmsg "initrd: mounting android system image from system rootfs"
+		tell_kmsg "mounting android system image from system rootfs"
 		mount -o loop,$MOUNT /ubuntu-system/var/lib/lxc/android/system.img /android-system
 	fi
 
@@ -444,7 +444,7 @@ mountroot() {
 	# Determine whether we should boot in rootfs or Android mode
 	if ( [ -e $imagefile ] || [ -n "$syspart" ] ) && [ "$BOOT_MODE" = "android" ]; then
 		# Bootloader says this is factory or charger mode, boot into Android.
-		tell_kmsg "initrd: Android boot mode for factory or charger mode"
+		tell_kmsg "Android boot mode for factory or charger mode"
 
 		mount /ubuntu-system -o remount,ro
 		mount --move /android-rootfs ${rootmnt}
@@ -469,20 +469,20 @@ mountroot() {
 		# Make sure we're booting into android's init
 		ln -s ../init ${rootmnt}/sbin/init
 		ln -s ../init ${rootmnt}/sbin/recovery
-		tell_kmsg "initrd: booting android..."
+		tell_kmsg "booting android..."
     elif [ -e $imagefile -o -n "$syspart" ]; then
 	    # Regular image boot
-		tell_kmsg "initrd: Normal boot"
+		tell_kmsg "Normal boot"
 
 		mount --move /ubuntu-system ${rootmnt}
 
 		# If either (android) /data/.writable_image or (on rootfs) 
 		# /.writable_image exist, mount the rootfs as rw
 		if [ -e /tmpmnt/.writable_image ] || [ -e ${rootmnt}/.writable_image ]; then
-			tell_kmsg "initrd: mounting $imagefile (image developer mode)"
+			tell_kmsg "mounting $imagefile (image developer mode)"
 			mountroot_status="$?"
 		else
-			tell_kmsg "initrd: mounting $imagefile (user mode)"
+			tell_kmsg "mounting $imagefile (user mode)"
 			mount -o remount,ro ${rootmnt}
 			mountroot_status="$?"
 		fi
@@ -494,8 +494,8 @@ mountroot() {
 
 		# Get device information
 		device=$(grep ^ro.product.device= /android-system/build.prop |sed -e 's/.*=//')
-		[ -z "$device" ] && device="unknown"
-		tell_kmsg "initrd: device is $device"
+		[ -z "$device" ] && device="unknown"; tell_kmsg "WARNING: Didn't find a device name. Is the Android system image mounted correctly?"
+		tell_kmsg "device is $device"
 
 		# Mount some tmpfs
 		mkdir -p ${rootmnt}/android
@@ -513,7 +513,7 @@ mountroot() {
 		mount_android_partitions "${rootmnt}/var/lib/lxc/android/rootfs/fstab*" ${rootmnt}/android
 
 		# system is a special case
-		tell_kmsg "initrd: moving Android system to /android/system"
+		tell_kmsg "moving Android system to /android/system"
 		mount --move /android-system ${rootmnt}/android/system
 
 		# Ubuntu overlay available in the Android system image (hardware specific configs)
@@ -541,7 +541,7 @@ mountroot() {
 		for user in ${rootmnt}/userdata/user-data/*
 		do
 			if [ -d ${rootmnt}/custom/home ] && [ ! -e "$user/.customized" ]; then
-				tell_kmsg "initrd: copying custom content tp "
+				tell_kmsg "copying custom content tp "
 				cp -Rap ${rootmnt}/custom/home/* "$user/"
 				cp -Rap ${rootmnt}/custom/home/.[a-zA-Z0-9]* "$user/"
 				touch "$user/.customized"
@@ -552,7 +552,7 @@ mountroot() {
 
 	else
 		# Possibly a re-partitioned device
-		tell_kmsg "initrd: Couldn't find a system partition."
+		tell_kmsg "Couldn't find a system partition."
 		panic "Couldn't find a system partition. Spawning adbd ..."
 	fi
 

--- a/initramfs/scripts/touch
+++ b/initramfs/scripts/touch
@@ -244,7 +244,7 @@ process_bind_mounts() {
 	# Prepare the fstab
 	FSTAB=${rootmnt}/etc/fstab
 	touch ${rootmnt}/run/image.fstab
-	mount -o bind ${rootmnt}/run/image.fstab $FSTAB || panic "drop to adb"
+	mount -o bind ${rootmnt}/run/image.fstab $FSTAB || panic "Could not bind-mount fstab"
 	echo "/dev/root / rootfs defaults,ro 0 0" >> $FSTAB
 
 	tell_kmsg "Adding bind-mounts to $FSTAB"
@@ -365,8 +365,7 @@ mountroot() {
 	fi
 
 	if [ -z "$path" ]; then
-		tell_kmsg "Couldn't find data partition. Spawning adbd ..."
-		panic "Couldn't find data partition. Spawning adbd ..."
+		panic "Couldn't find data partition."
 	fi
 
 	tell_kmsg "checking filesystem integrity for the userdata partition"
@@ -552,8 +551,7 @@ mountroot() {
 
 	else
 		# Possibly a re-partitioned device
-		tell_kmsg "Couldn't find a system partition."
-		panic "Couldn't find a system partition. Spawning adbd ..."
+		panic "Couldn't find a system partition."
 	fi
 
 	[ "$quiet" != "y" ] && log_begin_msg "Running /scripts/local-bottom"


### PR DESCRIPTION
This started as "Hey, let me just add the functionality for the 'halium' or 'ubports'-style file layout." It finished as so much more.

This is a refactor that adds features, but generally makes the `touch` script easier to follow by deleting duplicated code and moving long routines to separate functions. 

* Added features
  * 'halium' and 'ubports' file layouts are separate
  * it's easier to add new logging with the 'tell_kmsg function
  * The panic reason is printed in kmsg and on the device's serial number so it's easy to see why you're stuck in initrd
  * Fix for #12 

## Testing this PR

### Ubuntu Touch

Install Ubuntu Touch using [xenial-actuallyfixit rootstock](https://github.com/UniversalSuperBox/rootstock-ng/tree/xenial-actuallyfixit) to test "ubports" file layout functionality. Simply boot the device as you normally would. 

Install Ubuntu Touch using [xenial-initchange rootstock](https://github.com/UniversalSuperBox/rootstock-ng/tree/xenial-initchange) to test Ubuntu Touch with the Halium file layout. Simply boot the device as you normally would. 

The expected result for Ubuntu Touch is that no behavior changes whatsoever except for a few log messages. All mounts, overlays, etc should be exactly the same.

### Halium

Use the instructions in halium/projectmanagement#40 to boot Halium using these changes.